### PR TITLE
Derive Eq instance for HsModule

### DIFF
--- a/Language/Haskell/Syntax.hs
+++ b/Language/Haskell/Syntax.hs
@@ -163,9 +163,9 @@ data HsCName
 data HsModule = HsModule SrcLoc Module (Maybe [HsExportSpec])
                          [HsImportDecl] [HsDecl]
 #ifdef __GLASGOW_HASKELL__
-  deriving (Show,Typeable,Data)
+  deriving (Eq,Show,Typeable,Data)
 #else
-  deriving (Show)
+  deriving (Eq,Show)
 #endif
 
 -- | Export specification.


### PR DESCRIPTION
Derive `HsModule`  an instance of `Eq` type class.