### PR TITLE
v1.0.4.2: drop support for GHC 7

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250506
+# version: 0.19.20250821
 #
-# REGENDATA ("0.19.20250506",["github","haskell-src.cabal"])
+# REGENDATA ("0.19.20250821",["github","haskell-src.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.0.20250819
+            compilerKind: ghc
+            compilerVersion: 9.14.0.20250819
+            setup-method: ghcup-prerelease
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
@@ -110,11 +115,26 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
@@ -136,7 +156,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -164,6 +184,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -212,9 +244,16 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_haskell_src}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package haskell-src" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package haskell-src" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package haskell-src" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(haskell-src)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/Language/Haskell/ParseMonad.hs
+++ b/Language/Haskell/ParseMonad.hs
@@ -14,8 +14,8 @@
 
 {-# LANGUAGE CPP #-}
 
-#if __GLASGOW_HASKELL__ >= 902
-{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+#if __GLASGOW_HASKELL__ >= 900
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 #endif
 
 module Language.Haskell.ParseMonad(

--- a/Language/Haskell/Syntax.hs
+++ b/Language/Haskell/Syntax.hs
@@ -18,7 +18,7 @@
 --
 --   * parameters of type class assertions are unrestricted
 --
--- For GHC, we also derive 'Typeable' and 'Data' for all types.
+-- For GHC, we also derive 'Data' for all types.
 
 -----------------------------------------------------------------------------
 
@@ -75,7 +75,7 @@ data SrcLoc = SrcLoc {
                 srcColumn   :: Int
                 }
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Ord,Show,Typeable,Data)
+  deriving (Eq,Ord,Show,Data)
 #else
   deriving (Eq,Ord,Show)
 #endif
@@ -83,7 +83,7 @@ data SrcLoc = SrcLoc {
 -- | The name of a Haskell module.
 newtype Module = Module String
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Ord,Show,Typeable,Data)
+  deriving (Eq,Ord,Show,Data)
 #else
   deriving (Eq,Ord,Show)
 #endif
@@ -100,7 +100,7 @@ data HsSpecialCon
                                 --   constructors @(,)@ etc.
         | HsCons                -- ^ List data constructor @(:)@.
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Ord,Show,Typeable,Data)
+  deriving (Eq,Ord,Show,Data)
 #else
   deriving (Eq,Ord,Show)
 #endif
@@ -112,7 +112,7 @@ data HsQName
         | UnQual HsName         -- ^ Unqualified name.
         | Special HsSpecialCon  -- ^ Built-in constructor with special syntax.
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Ord,Show,Typeable,Data)
+  deriving (Eq,Ord,Show,Data)
 #else
   deriving (Eq,Ord,Show)
 #endif
@@ -122,7 +122,7 @@ data HsName
         = HsIdent String        -- ^ /varid/ or /conid/.
         | HsSymbol String       -- ^ /varsym/ or /consym/.
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Ord,Show,Typeable,Data)
+  deriving (Eq,Ord,Show,Data)
 #else
   deriving (Eq,Ord,Show)
 #endif
@@ -132,7 +132,7 @@ data HsQOp
         = HsQVarOp HsQName      -- ^ Variable operator (/qvarop/).
         | HsQConOp HsQName      -- ^ Constructor operator (/qconop/).
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Ord,Show,Typeable,Data)
+  deriving (Eq,Ord,Show,Data)
 #else
   deriving (Eq,Ord,Show)
 #endif
@@ -142,7 +142,7 @@ data HsOp
         = HsVarOp HsName        -- ^ Variable operator (/varop/).
         | HsConOp HsName        -- ^ Constructor operator (/conop/).
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Ord,Show,Typeable,Data)
+  deriving (Eq,Ord,Show,Data)
 #else
   deriving (Eq,Ord,Show)
 #endif
@@ -153,7 +153,7 @@ data HsCName
         = HsVarName HsName      -- ^ Name of a method or field.
         | HsConName HsName      -- ^ Name of a data constructor.
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Ord,Show,Typeable,Data)
+  deriving (Eq,Ord,Show,Data)
 #else
   deriving (Eq,Ord,Show)
 #endif
@@ -162,7 +162,7 @@ data HsCName
 data HsModule = HsModule SrcLoc Module (Maybe [HsExportSpec])
                          [HsImportDecl] [HsDecl]
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -182,7 +182,7 @@ data HsExportSpec
          | HsEModuleContents Module             -- ^ @module M@:
                         -- Re-export a module.
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -200,7 +200,7 @@ data HsImportDecl = HsImportDecl
                         -- by @hiding@.
         }
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -217,7 +217,7 @@ data HsImportSpec
                         -- A class imported with some of its methods, or
                         -- a datatype imported with some of its constructors.
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -228,7 +228,7 @@ data HsAssoc
          | HsAssocLeft  -- ^ Left-associative operator (declared with @infixl@).
          | HsAssocRight -- ^ Right-associative operator (declared with @infixr@).
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -247,7 +247,7 @@ data HsDecl
          | HsForeignImport SrcLoc String HsSafety String HsName HsType
          | HsForeignExport SrcLoc String String HsName HsType
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -256,7 +256,7 @@ data HsDecl
 data HsMatch
          = HsMatch SrcLoc HsName [HsPat] HsRhs {-where-} [HsDecl]
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -268,7 +268,7 @@ data HsConDecl
          | HsRecDecl SrcLoc HsName [([HsName],HsBangType)]
                                 -- ^ Record constructor.
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -279,7 +279,7 @@ data HsBangType
          = HsBangedTy   HsType  -- ^ Strict component, marked with \"@!@\".
          | HsUnBangedTy HsType  -- ^ Non-strict component.
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -290,7 +290,7 @@ data HsRhs
          | HsGuardedRhss  [HsGuardedRhs]
                                 -- ^ Guarded right hand side (/gdrhs/).
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -300,7 +300,7 @@ data HsRhs
 data HsGuardedRhs
          = HsGuardedRhs SrcLoc HsExp HsExp
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -310,7 +310,7 @@ data HsSafety
         = HsSafe        -- ^ Call may generate callbacks.
         | HsUnsafe      -- ^ Call will not generate callbacks.
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Ord,Show,Typeable,Data)
+  deriving (Eq,Ord,Show,Data)
 #else
   deriving (Eq,Ord,Show)
 #endif
@@ -320,7 +320,7 @@ data HsSafety
 data HsQualType
          = HsQualType HsContext HsType
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -333,7 +333,7 @@ data HsType
          | HsTyVar   HsName             -- ^ Type variable.
          | HsTyCon   HsQName            -- ^ Named type or type constructor.
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -360,7 +360,7 @@ data HsLiteral
         | HsFloatPrim   Rational        -- ^ GHC unboxed float literal.
         | HsDoublePrim  Rational        -- ^ GHC unboxed double literal.
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -420,7 +420,7 @@ data HsExp
         | HsWildCard                    -- ^ (patterns only)
         | HsIrrPat HsExp                -- ^ (patterns only)
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -442,7 +442,7 @@ data HsPat
         | HsPWildCard                   -- ^ Wildcard pattern (@_@).
         | HsPIrrPat HsPat               -- ^ Irrefutable pattern (@~@).
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -451,7 +451,7 @@ data HsPat
 data HsPatField
         = HsPFieldPat HsQName HsPat
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -466,7 +466,7 @@ data HsStmt
                                 -- in a list comprehension, a guard expression.
         | HsLetStmt [HsDecl]    -- ^ Local bindings.
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -475,7 +475,7 @@ data HsStmt
 data HsFieldUpdate
         = HsFieldUpdate HsQName HsExp
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -484,7 +484,7 @@ data HsFieldUpdate
 data HsAlt
         = HsAlt SrcLoc HsPat HsGuardedAlts [HsDecl]
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -493,7 +493,7 @@ data HsGuardedAlts
         = HsUnGuardedAlt HsExp          -- ^ @->@ /exp/.
         | HsGuardedAlts  [HsGuardedAlt] -- ^ /gdpat/.
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif
@@ -503,7 +503,7 @@ data HsGuardedAlts
 data HsGuardedAlt
         = HsGuardedAlt SrcLoc HsExp HsExp
 #ifdef __GLASGOW_HASKELL__
-  deriving (Eq,Show,Typeable,Data)
+  deriving (Eq,Show,Data)
 #else
   deriving (Eq,Show)
 #endif

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+## 1.0.4.2
+
+_Andreas Abel, 2025-08-28_
+
+  - Drop support for GHC 7.
+  - Tested with GHC 8.0 - 9.14 alpha1.
+
 ## 1.0.4.1
 
 _Andreas Abel, 2024-09-22_

--- a/haskell-src.cabal
+++ b/haskell-src.cabal
@@ -1,7 +1,7 @@
 cabal-version:  1.18
 name:           haskell-src
 -- don't forget to update the changelog.md!
-version:        1.0.4.1
+version:        1.0.4.2
 build-type:     Simple
 
 license:        BSD3

--- a/haskell-src.cabal
+++ b/haskell-src.cabal
@@ -1,4 +1,4 @@
-cabal-version:  >=1.10
+cabal-version:  1.18
 name:           haskell-src
 -- don't forget to update the changelog.md!
 version:        1.0.4.1
@@ -34,7 +34,7 @@ tested-with:
   GHC == 8.2.2
   GHC == 8.0.2
 
-extra-source-files: changelog.md
+extra-doc-files: changelog.md
 
 source-repository head
     type:     git
@@ -49,21 +49,17 @@ library
         Language.Haskell.Syntax,
         Language.Haskell.ParseUtils
 
-  build-depends:   base       >= 4.3     && < 5
+  build-depends:   base       >= 4.9     && < 5
                      -- no confirmed upper bound on base yet
                  , syb        >= 0.1     && < 0.8
                  , pretty     >= 1.0.1.2 && < 1.2
                  , array      >= 0.3     && < 0.6
 
-  if !impl(ghc >= 8.0)
-    build-depends: fail       == 4.9.*
-                 , semigroups == 0.18.*
-                     -- semigroups >= 0.19 does not build with ghc < 8
-  else
-    ghc-options: -Wcompat -Wnoncanonical-monad-instances
-
   build-tools: happy >= 1.19
 
   default-language: Haskell98
 
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wnoncanonical-monad-instances

--- a/haskell-src.cabal
+++ b/haskell-src.cabal
@@ -20,6 +20,7 @@ description:
     <http://www.haskell.org/onlinereport/ Haskell 98> code.
 
 tested-with:
+  GHC == 9.14.1
   GHC == 9.12.2
   GHC == 9.10.2
   GHC == 9.8.4


### PR DESCRIPTION
- **Drop support for GHC 7**
  

- **Bump Haskell CI to GHC 9.14 alpha1**
  

- **Bump version to 1.0.4.2 and changelog**

Candidate: https://hackage.haskell.org/package/haskell-src-1.0.4.2/candidate
  